### PR TITLE
Add support for jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It use [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store) to m
 - [expect](https://redux-things.github.io/redux-actions-assertions/expect.html)
 - [expect.js](https://redux-things.github.io/redux-actions-assertions/expectjs.html)
 - [jasmine](https://redux-things.github.io/redux-actions-assertions/jasmine.html)
+- [jest](https://redux-things.github.io/redux-actions-assertions/jest.html)
 - [should](https://redux-things.github.io/redux-actions-assertions/should.html)
 - [tape](https://redux-things.github.io/redux-actions-assertions/tape.html)
 - [pure javascript assertion](https://redux-things.github.io/redux-actions-assertions/javascript.html)

--- a/documentation/jest.md
+++ b/documentation/jest.md
@@ -1,0 +1,54 @@
+# [jest](https://github.com/facebook/jest)
+
+## Registration
+
+```js
+// add these two lines in your setupTestFrameworkScriptFile:
+// http://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string
+import { registerAssertions } from 'redux-actions-assertions/jest';
+
+beforeEach(registerAssertions);
+```
+
+## Usage
+
+### .toDispatchActions
+
+> `expect(action).toDispatchActions(expectedActions, done)`
+
+Asserts that when given `action` is dispatched it will dispatch `expectedActions`. `action` can be plain object (action) or function (action creator). `expectedActions` can be can be plain object (action) or function (action creator) or array of objects/functions.
+
+```js
+expect(myActionCreator())
+  .toDispatchActions({ type: 'MY_ACTION_START' }, done);
+```
+
+### .toNotDispatchActions
+
+> `expect(action).toNotDispatchActions(expectedActions, done)`
+
+Asserts that when given `action` is dispatched it will not dispatch `expectedActions`. `action` can be plain object (action) or function (action creator). `expectedActions` can be can be plain object (action) or function (action creator) or array of objects/functions.
+
+```js
+expect(myActionCreator())
+  .toNotDispatchActions({ type: 'MY_ACTION_START' }, done);
+```
+
+### .toDispatchActionsWithState
+
+> `expect(action).toDispatchActionsWithState(state, expectedActions, done)`
+
+Asserts that store initialised with `state` before `action` is dispatched.
+
+```js
+const state = {property: 'value'};
+const expectedActions = [{ type: 'MY_ACTION_START' }, finishActionCreator()];
+expect(myActionCreator())
+  .toDispatchActionsWithState(state, expectedActions, done);
+```
+You can also use its variant `.toNotDispatchActionsWithState`:
+
+```js
+expect(myActionCreator())
+  .toNotDispatchActionsWithState(state, expectedActions, done);
+```

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "test:expect": "mocha --compilers js:babel-register --reporter spec test/expect/*.js",
     "test:expectjs": "mocha --compilers js:babel-register --reporter spec test/expectjs/*.js",
     "test:jasmine": "jasmine JASMINE_CONFIG_PATH=test/jasmine/jasmine.json",
+    "test:jest": "jest --config test/jest/jest.json",
     "test:should": "mocha --compilers js:babel-register --reporter spec test/should/*.js",
     "test:tape": "tape --require babel-register test/tape/*.js",
-    "test": "npm run test:index && npm run test:chai && npm run test:expect && npm run test:expectjs && npm run test:jasmine && npm run test:should && npm run test:tape",
+    "test": "npm run test:index && npm run test:chai && npm run test:expect && npm run test:expectjs && npm run test:jasmine && npm run test:jest && npm run test:should && npm run test:tape",
     "prepublish": "rimraf build && babel src --out-dir build --copy-files"
   },
   "repository": {
@@ -38,6 +39,7 @@
     "expect": "^1.20.1",
     "expect.js": "^0.3.1",
     "jasmine": "^2.5.2",
+    "jest": "^18.1.0",
     "mocha": "^2.4.5",
     "redux-thunk": "^2.1.0",
     "rimraf": "^2.5.2",

--- a/src/jasmine.js
+++ b/src/jasmine.js
@@ -57,6 +57,5 @@ function registerAssertions() {
 }
 
 export {
-  registerAssertions,
-  matchers
+  registerAssertions
 };

--- a/src/jest.js
+++ b/src/jest.js
@@ -1,0 +1,3 @@
+import { registerAssertions } from './jasmine';
+
+export { registerAssertions };

--- a/test/jest/index.js
+++ b/test/jest/index.js
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+import thunk from 'redux-thunk';
+import { registerMiddlewares } from '../../src';
+import actions from '../testingData/actions';
+
+registerMiddlewares([thunk]);
+
+describe('jest', () => {
+  describe('toDispatchActionsWithState', () => {
+    it('should accept object', (done) => {
+      const state = { property: 'value' };
+      expect(actions.actionCreatorWithGetState())
+        .toDispatchActionsWithState(state, actions.actionWithGetState({ property: 'value' }), done);
+    });
+  });
+
+  describe('.toDispatchActions', () => {
+    it('should accept single action', (done) => {
+      expect(actions.start()).toDispatchActions(actions.start(), done);
+    });
+
+    it('should accept array with one action', (done) => {
+      expect(actions.start()).toDispatchActions([actions.start()], done);
+    });
+
+    it('should accept array with multiple actions', (done) => {
+      expect(actions.asyncActionCreator())
+        .toDispatchActions(actions.expectedActions, done);
+    });
+
+    it('should accept array with nested async action creators', (done) => {
+      expect(actions.parentAsyncActionCreator())
+        .toDispatchActions(actions.expectedParentActions, done);
+    });
+  });
+
+  describe('.toNotDispatchActions', () => {
+    it('should accept single action', (done) => {
+      expect(actions.start()).toNotDispatchActions(actions.anotherStart(), done);
+    });
+
+    it('should accept array with one action', (done) => {
+      expect(actions.start()).toNotDispatchActions([actions.anotherStart()], done);
+    });
+
+    it('should accept array with multiple actions', (done) => {
+      expect(actions.asyncActionCreator())
+        .toNotDispatchActions(actions.anotherExpectedActions, done);
+    });
+
+    it('should accept array with nested async action creators', (done) => {
+      expect(actions.parentAsyncActionCreator())
+        .toNotDispatchActions(actions.anotherParentExpectedActions, done);
+    });
+  });
+});

--- a/test/jest/jest.json
+++ b/test/jest/jest.json
@@ -1,0 +1,5 @@
+{
+  "testPathDirs": ["<rootDir>/test/jest"],
+  "testRegex": "index.js",
+  "setupTestFrameworkScriptFile": "<rootDir>/test/jest/setupFramework.js"
+}

--- a/test/jest/setupFramework.js
+++ b/test/jest/setupFramework.js
@@ -1,0 +1,3 @@
+import { registerAssertions } from '../../src/jest';
+
+beforeEach(registerAssertions);


### PR DESCRIPTION
I added support for jest through the jasmine matchers I wrote for #34.
Sadly I wasn't able to get the `.not` syntax to work; a solution for now is to use our negative variants (for instance `expect(..).toNotDispatchActions`)

This closes #33 